### PR TITLE
Criados os documentos que descrevem o formato dos eventos do GOJS

### DIFF
--- a/CODIGO-DE-CONDUTA.md
+++ b/CODIGO-DE-CONDUTA.md
@@ -1,0 +1,48 @@
+# Código de Conduta
+
+O grupo de discussão deve ser um lugar seguro e convidativo para pessoas independentemente de:
+
+- Gênero, identidade de gênero ou expressão de gênero
+- Orientação sexual
+- Restrições físicas
+- Aparência física (incluindo, mas não limitado, ao tamanho do corpo)
+- Raça e/ou etnia
+- Idade
+- Religião ou a falta dela
+- Escolha de tecnologias
+
+Como membro deste grupo, você concorda que:
+
+* Nós somos, coletivamente e individualmente, comprometidos com a segurança e inclusão.
+* Nós adotamos a política de tolerância zero para assédio, perseguições ou discriminações.
+* Nós respeitamos os limites, identidade e privacidade das pessoas.
+* Nós nos abstemos de usar linguagem que possa ser considerada opressiva, como comentários sexistas, racistas, homofóbicos, transfóbicos, classistas ou que discrimine pessoas com qualquer tipo de deficiência, mas este Código de Conduta não está limitado a apenas estes.
+* Nós evitamos tópicos ofensivos como forma de humor.
+* Nós evitamos tópicos que fogem ao escopo do grupo, como conteúdo político.
+
+Nós trabalhamos ativamente para:
+
+* Ser uma comunidade segura.
+* Cultivar uma rede de suporte e encorajamento para todos.
+* Encorajar variadas formas de expressão de maneira responsável.
+
+Nós condenamos:
+
+* Perseguição, _doxxing_ (investigar a vida de uma pessoa sem autorização) ou publicações indevidas de informações privadas.
+* Ameaças e assédio de qualquer tipo.
+* Qualquer comportamento que comprometa a segurança dos demais membros.
+
+**Essas atitudes NÃO SÃO CORRETAS.** Se você não concorda com estas regras, por favor, cancele sua inscrição neste grupo.
+
+O desrespeito às regras desta comunidade, descritas nesse documento, acarretará em consequências:
+
+- Publicações que não estiverem de acordo com este Código de Conduta serão removidas.
+- Cabe aos administradores decidir se você será removido temporariamente ou permanentemente deste grupo.
+
+**Se você sofrer algum tipo de abuso, assédio, discriminação, ou se sentir inseguro, fale com um administrador. Se o administrador for a pessoa que você quer reportar, fale com outro administrador.**
+
+*A posição de administrador é para fins de moderação imparcial; eles não vão moderar ou editar o conteúdo postado pelos membros do grupo para outras finalidades ou por motivos estritamente pessoais.*
+
+--
+
+*Esse texto é um documento em constante edição, e pode ser alterado no futuro.* Código de conduta baseado em: https://github.com/fnando/codigo-de-conduta e https://github.com/AndroidDevBR/Codigo-De-Conduta

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Formatos de eventos
 - **Meet-ups com palestras**, são os eventos mais comuns da comunidade e recomendamos que sejam realizados mensalmente. Normalmente possuem duração de 3 horas com uma recepção/networking de 30 minutos, 2 ou 3 slots de tempo com cerca de 20 minutos cada para apresentação de palestras. Ficando o tempo restante mais networking.
 - **Encontros para networking**, são eventos esporádicos que tem como objetivo permitir que os membros da comunidade se conheçam. Esses são os eventos mais versáteis pois podem acontecer em qualquer lugar (bares, shoppings, auditórios, etc.). O importante é que os participantes tenham espaço para conversar e trocar experiências.
-- **Hackathons**, são eventos onde a comunidade se reúne (presencial ou remotamente) para criar projetos em torno de um tema específico. Atualmente não temos um modelo para seguir para esse tipo de evento, porém podemos utilizar o [The Hack Day Manifesto](https://hackdaymanifesto.com/) e o [Hackathon Guide](https://hackathon.guide/) como guias.
+- **Hackathons**, são eventos onde a comunidade se reúne (presencial ou remoto) para criar projetos em torno de um tema específico. Atualmente não temos um modelo para seguir para esse tipo de evento, porém podemos utilizar o [The Hack Day Manifesto](https://hackdaymanifesto.com/) e o [Hackathon Guide](https://hackathon.guide/) como guias.
 
 ## Checklist para organização de eventos
 
@@ -13,7 +13,7 @@
 
 Independentemente do formato escolhido para o evento, é importante que o mesmo seja agendado e divulgado com antecedência. Anunciar e divulgar o evento de 3 a 4 semanas de antecedência dará tempo para as pessoas se organizarem para comparecer ao mesmo.
 
-Também recomendamos ser claro claro sobre qual audiência o facilitador está buscando atingir com o encontro. Por exemplo, o evento é um tema específico? Em iniciantes? etc..
+Também recomendamos ser claro sobre qual audiência o facilitador está buscando atingir com o encontro. Por exemplo, o evento é um tema específico? Em iniciantes? etc..
 
 Após agendar o evento, é necessário fazer com que as pessoas saibam que ele existe. Os canais de comunicação podem variar, mas alguns para se considerar:
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,125 @@
-# Submissão de palestras para os Meetups
+# Guia GoJS
 
-Toda 3ª quinta-feira do mês, a nossa comunidade promove um meetup, onde geramente acontecem palestras, de no máximo 18 minutos.
+## Formatos de eventos
+- **Meet-ups com palestras**, são os eventos mais comuns da comunidade e recomendamos que sejam realizados mensalmente. Normalmente possuem duração de 3 horas com uma recepção/networking de 30 minutos, 2 ou 3 slots de tempo com cerca de 20 minutos cada para apresentação de palestras. Ficando o tempo restante mais networking.
+- **Encontros para networking**, são eventos esporádicos que tem como objetivo permitir que os membros da comunidade se conheçam. Esses são os eventos mais versáteis pois podem acontecer em qualquer lugar (bares, shoppings, auditórios, etc.). O importante é que os participantes tenham espaço para conversar e trocar experiências.
+- **Hackathons**, são eventos onde a comunidade se reúne (presencial ou remotamente) para criar projetos em torno de um tema específico. Atualmente não temos um modelo para seguir para esse tipo de evento, porém podemos utilizar o [The Hack Day Manifesto](https://hackdaymanifesto.com/) e o [Hackathon Guide](https://hackathon.guide/) como guias.
 
-## Como funciona a submissão?
+## Checklist para organização de eventos
 
-Para todo meetup que realizarmos, iremos criar uma issue neste repositório com a data do meetup. Depois de submetidas, haverá uma votação com likes. As 5 palestras mais votadas serão escolhidas para serem apresentadas no meetup daquele dia.
+...
+
+## Agendamento e promoção de encontros
+
+Independentemente do formato escolhido para o evento, é importante que o mesmo seja agendado e divulgado com antecedência. Anunciar e divulgar o evento de 3 a 4 semanas de antecedência dará tempo para as pessoas se organizarem para comparecer ao mesmo.
+
+Também recomendamos ser claro claro sobre qual audiência o facilitador está buscando atingir com o encontro. Por exemplo, o evento é um tema específico? Em iniciantes? etc..
+
+Após agendar o evento, é necessário fazer com que as pessoas saibam que ele existe. Os canais de comunicação podem variar, mas alguns para se considerar:
+
+- Slack do GoJS
+- Eventos de tecnologia da [Agenda Compartilhada](bit.ly/startupgoagenda)
+- Grupos do Facebook (Front-end Goiás, GDG Goiânia, Instituo de Informática UFG, etc.)
+- Empresas que utilizam as tecnologias tema do encontro
+- Utilização de redes sociais (Facebook, Twitter, Instagram, etc.) utilizando a hashtag #gojs
+
+Também fornecemos dois modelos de imagem que você pode usar para criar banners digitais para promover o evento.
+
+![img1]()
+![img2]()
+
+Para usar os templates:
+
+1. Acesse o [modelo no Google Docs](link.to) e faça uma cópia
+2. Adicione as informações do seu evento em um dos dois slides
+3. Vá em `File > Download As` para realizar o download da imagem no formato `.png`
+
+## Proporcionando uma experiência positiva
+O GoJS está empenhado em fornecer uma experiência positiva para os membros da comunidade, tanto online nas nossas ferramentas da comunidade como offline em nossos meet-ups. Por favor, certifique-se de ler nosso [Código de Conduta](CODIGO-DE-CONDUTA.md) para saber mais sobre os comportamentos aceitáveis que todos os encontros devem seguir.
+
+Busque formas de receber os feedbacks dos participantes dos eventos que você realiza. Encorajamos você a analisar esse feedback para aprender sobre o que as pessoas estão gostando em seus encontros e onde as pessoas estão fornecendo sugestões sobre como melhorar a experiência. 
+
+## Selecionando o local
+O local a ser realizado deve ter suporte para pelo menos dez pessoas.
+
+Ao buscar um local analise fatores como: tamanho da sala, projetores, ar condicionado, localização, ônibus, estacionamento, etc.
+
+### Locais sugeridos:
+
+- Supera Tecnologia (adicionar link para issue descrevendo como organizar evento na Supera)
+- SEBRAE (adicionar link para issue descrevendo como organizar evento na SEBRAE)
+
+## Conteúdo e palestras
+Nos esforçamos para criar um ambiente em que as pessoas interessadas em javascript - desenvolvedores, iniciantes e usuários avançados - possam reunir e falar sobre as tecnologias que estamos criando e aprender o que há de novo no ecossistema. Por favor, não utilize os encontros para promover webinars ou eventos não relacionados ao GoJS.
+
+Os tópicos abordados devem estar de alguma forma vinculados ao ecossistema javascript, como introduções à comunidade e aos projetos, demonstrações de aplicativos, explicações sobre como configurar um ambiente de desenvolvimento ou apresentações de casos de uso que uma pessoa ou organização está trabalhando. A chave é escolher os tópicos certos para o seu público. 
+
+### Convidados
+
+Quando existe a possiblidade de algum especialista em um assunto atender ao encontro, é normal e até recomendado que o tema gire em torno da especialidade deste, caso o mesmo concorde. Assim podemos absorver o máximo de conhecimento que a pessoa especialista possa compartilhar.
+
+### Seleção de palestras
+
+Para cada encontro realizado será criada uma issue no repositório [meetup-gojs](https://github.com/frontendgoias/meetup-gojs) com a data do encontro. Todos os interessados em apresentar uma palestra ou trabalho de qualquer natureza deverão submeter um comentário nessa issue contendo a descrição da apresentação conforme o modelo abaixo.
+
+```
+**Título da palestra**
+
+Descrição: seja breve
+
+*Categoria: digite quantas quiser separadas por vírgula*
+*Dificuldade: escolha entre Iniciante, Intermediário ou Avançado*
+```
+
+Os membros da comunidade devem votar com um :+1: nas palestras que acharem mais interessante e 2 dias antes do encontro a votação será encerrada e as mais bem votadas serão escolhidas até que se preencham os slots de tempo para palestras dentro da programação do encontro.
+
+## Controle de participantes
+
+Recomendamos o uso da plataforma [Congressy](https://www.congressy.com/), que permite o cadastro de novos eventos gratuitamente, desde que não seja cobrada a entrada (o que é o caso do GOJS).
+
+Os campos exigidos geralmente são:
+
+* Nome completo
+* E-mail
+* Documento com foto (para controle na portaria das empresas)
+
+**IMPORTANTE**: Para a empresa anfitriã, envie APENAS o nome do participante e o documento, quando necessário. A privacidade dos participantes é algo que devemos zelar por obrigação, e como procedimento padrão.
+
+Ainda, caso  a empresa tenha fornecido o espaço livre de custos, e faz questão de ter a lista de e-mail de todos que participaram, a mesma deve ficar explícita para cada participante que seu e-mail será compartilhado e, fazendo a inscrição, o participante concorda com este termo.
+
+![Os sete passos da execução de uma reunião do FEMUG](http://i.imgur.com/3b5eomV.png)
+
+Como guia rápido de fluxo de controle de participantes podemos usar o documento acima que foi criado em cima da experiência adquirida na organização do então FEMUSP (que se tornou FEMUG-SP).
+
+## Dicas
+### Encontrando um local
+
+Muitas empresas possuem interesse em se tornar visíveis para a comunidade de desenvolvedores. Para ter um local e o evento ser realizado, crie um formulário e envie para pessoas de empresas que possuam salas de reuniões e queiram sediar um ou mais encontros. Uma vez que o contato é firmado, se torna algo simples continuar angariando locais.
+
+No formulário de questões do FEMUSP (encontro que originou o FEMUG), existem as seguintes perguntas:
+
+* Qual seu nome? (do contato)
+* Qual empresa você trabalha?
+* Qual seu e-mail?
+* Qual o site da sua empresa?
+* Quantas pessoas sua sala de reuniões ou auditório comporta?
+* Onde fica sua empresa? (Endereço e referências)
+* Tem conexão wi-fi para os participantes?
+* Sua empresa pode ceder um café para uma pausa, para todos os participantes?
+* Quais dias da semana você prefere que o encontro seja realizado?
+* Em qual horário?
+	* Recomendamos um encontro de duas horas, começando a janela 7pm
+* Observações gerais.
+
+### Coffee break
+
+Uma vez que uma empresa concorde em ceder um espaço, geralmente a mesma costuma ceder o café com comes e bebes para todos os participantes. Caso o mesmo não ocorra, você pode buscar uma empresa para patrocinar o mesmo, ou até mesmo rachar entre todos os participantes que concordarem. Tudo depende do público e das empresas envolvidas.
+
+- - - -
+
+Esse guia não deve servir como uma ferramenta para auxiliar o encontro a ter sucesso e não como regras rígidas que devem ser seguidas a risca. 
+
+Obrigado ao [FEMUG](https://github.com/femug/femug/blob/master/README.md)  por ter criado um guia tão incrível que decidimos apenas forká-lo e adaptar as nossas necessidades ;)
 
 ## Entre para o slack do GOJS
-
 No nosso slack, temos discussões toda semana sobre os mais diversos assuntos relacionados à JavaScript (ou não). Link para acessar [aqui](https://slackin-iztqicshbj.now.sh/).

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Guia GoJS
 
+## Sobre a comunidade
+
+Uma comunidade com pessoas interessadas compartilhar conhecimentos à respeito de JavaScript em Goiás. A ideia da comunidade é aproximar e reunir pessoas para uma maior troca de conhecimento e que o panorama geral do estado melhore cada vez mais.
+
 ## Formatos de eventos
 - **Meet-ups com palestras**, são os eventos mais comuns da comunidade e recomendamos que sejam realizados mensalmente. Normalmente possuem duração de 3 horas com uma recepção/networking de 30 minutos, 2 ou 3 slots de tempo com cerca de 20 minutos cada para apresentação de palestras. Ficando o tempo restante mais networking.
 - **Encontros para networking**, são eventos esporádicos que tem como objetivo permitir que os membros da comunidade se conheçam. Esses são os eventos mais versáteis pois podem acontecer em qualquer lugar (bares, shoppings, auditórios, etc.). O importante é que os participantes tenham espaço para conversar e trocar experiências.


### PR DESCRIPTION
A ideia desse PR é criar ferramentas que facilitem a organização dos eventos do GOJS, pois quanto mais fácil for organizar, mais fácil será passar o bastão e mais eventos com maior qualidade nós teremos.

Grande parte do conteúdo desse PR é baseado nos guias do FEMUG, que foram construídos com anos de experiência na organização de meet-ups, porém adaptados a nossa realidade goiana.

Esse PR ainda não está pronto para ser mergeado, ainda faltam criar alguns templates, guias na wiki, checklists, etc.. Porém acredito que já está maduro o suficiente para discutirmos a respeito.